### PR TITLE
Update mdbook version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ build-release:
 
 download-mdbook:
 	mkdir -p bin
-	curl -L https://github.com/rust-lang/mdBook/releases/download/v$(MDBOOK_VERSION)/mdbook-v$(MDBOOK_VERSION)-x86_64-unknown-linux-gnu.tar.gz | tar xvz -C ./bin
+	curl -L https://github.com/rust-lang/mdBook/releases/download/v$(MDBOOK_VERSION)/mdbook-v$(MDBOOK_VERSION)-x86_64-unknown-linux-musl.tar.gz | tar xvz -C ./bin
 	chmod +x ./bin/mdbook
 
 download-linter:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-MDBOOK_VERSION = 0.4.15
+MDBOOK_VERSION = 0.4.37
 
 build:
 	mdbook build


### PR DESCRIPTION
Deploy fails because of 
```
./bin/mdbook: /lib/x86_64-linux-gnu/libm.so.6: version `GLIBC_2.29' not found (required by ./bin/mdbook)
```

A suggestion from mdbook is to use the musl build, which is statically linked
https://github.com/rust-lang/mdBook/issues/2208#issuecomment-1817479005