### PR TITLE
fix httpql redirect

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -22,8 +22,8 @@ services:
         source: /features/workflows/convert
         destination: /features/testing/workflows/convert
       - type: redirect
-        source: /internals/httpql
-        destination: /concepts/httpql
+        source: /internals/httpql*
+        destination: /reference/httpql
       - type: redirect
         source: /internals/instances
         destination: /concepts/instances


### PR DESCRIPTION
`/internals/httpql` was redirecting to `/concepts/httpql` which gets into a redirect loop.
I fixed this by redirecting to `/reference/httpql`
The redirect issue still exists for this rule:
```
      - type: redirect
        source: /concepts/*
        destination: /concepts/essentials/*
```
where it will match for /concepts/essentials/xyz so you get redirected to /concepts/essentials/essentials/xyz while will match again etc...
